### PR TITLE
fix(#2758): reports presentation now consistent

### DIFF
--- a/src/reports/budgetcategorysummary.cpp
+++ b/src/reports/budgetcategorysummary.cpp
@@ -110,9 +110,11 @@ wxString mmReportBudgetCategorySummary::getHTMLText()
 
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, wxString::Format(headerStartupMsg
             ,  headingStr + "<br>" + _("( Estimated Vs Actual )")));
         hb.DisplayDateHeading(yearBegin, yearEnd);
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();

--- a/src/reports/budgetingperf.cpp
+++ b/src/reports/budgetingperf.cpp
@@ -166,8 +166,10 @@ wxString mmReportBudgetingPerformance::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, wxString::Format(_("Budget Performance for %s"), headingStr));
         hb.DisplayDateHeading(yearBegin, yearEnd);
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();

--- a/src/reports/cashflow.cpp
+++ b/src/reports/cashflow.cpp
@@ -214,8 +214,10 @@ wxString mmReportCashFlow::getHTMLText_i()
                                                                 "Cash Flow Forecast for %i Years Ahead",
                                                                 years ),
                                                                 years);
+        hb.showUserName();
         hb.addHeader(2, headerMsg );
         hb.addHeader(3, getAccountNames());
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();

--- a/src/reports/categexp.cpp
+++ b/src/reports/categexp.cpp
@@ -132,11 +132,12 @@ wxString mmReportCategoryExpenses::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, getReportTitle());
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), m_date_range->is_with_date());
         hb.addHeader(3, getAccountNames());
+        hb.addReportCurrency();
         hb.addDateNow();
-        hb.addLineBreak();
     }
     hb.endDiv();
 
@@ -341,11 +342,12 @@ wxString mmReportCategoryOverTimePerformance::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, getReportTitle());
         hb.addHeader(3, getAccountNames());
         hb.DisplayDateHeading(date_range->start_date(), date_range->end_date(), date_range->is_with_date());
+        hb.addReportCurrency();
         hb.addDateNow();
-        hb.addLineBreak();
     }
     hb.endDiv();
 

--- a/src/reports/forecast.cpp
+++ b/src/reports/forecast.cpp
@@ -64,8 +64,10 @@ wxString mmReportForecast::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, getReportTitle());
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), m_date_range->is_with_date());
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();

--- a/src/reports/htmlbuilder.cpp
+++ b/src/reports/htmlbuilder.cpp
@@ -129,19 +129,26 @@ void mmHTMLBuilder::init()
         , mmex::getProgramName()
         , wxString::Format("%d", Option::instance().getHtmlFontSize())
     );
+}
 
+void mmHTMLBuilder::showUserName()
+{
     //Show user name if provided
     if (Option::instance().UserName() != "")
-    {
-        addDivContainer("shadowTitle");
-            addHeader(2, Option::instance().UserName());
-        endDiv();
-    }
+        addHeader(2, Option::instance().UserName());
 }
 
 void mmHTMLBuilder::addHeader(int level, const wxString& header)
 {
     html_ += wxString::Format(tags::HEADER, level, header, level);
+}
+
+void mmHTMLBuilder::addReportCurrency()
+{
+    wxString base_currency_symbol;
+    wxASSERT_MSG(Model_Currency::GetBaseCurrencySymbol(base_currency_symbol), "Could not find base currency symbol");
+
+    addHeader(4, wxString::Format("%s: %s", _("Currency"), base_currency_symbol));  
 }
 
 void mmHTMLBuilder::addDateNow()
@@ -199,11 +206,21 @@ void mmHTMLBuilder::addTotalRow(const wxString& caption, int cols
     this->endTableRow();
 }
 
-void mmHTMLBuilder::addTotalRow(const wxString& caption, int cols, const std::vector<double>& data)
+void mmHTMLBuilder::addCurrencyTotalRow(const wxString& caption, int cols, const std::vector<double>& data)
 {
     std::vector<wxString> data_str;
     for (const auto& value : data)
         data_str.push_back(Model_Currency::toCurrency(value));
+    this->addTotalRow(caption, cols, data_str);
+}
+
+void mmHTMLBuilder::addMoneyTotalRow(const wxString& caption, int cols, const std::vector<double>& data)
+{
+    std::vector<wxString> data_str;
+    int precision = Model_Currency::precision(Model_Currency::GetBaseCurrency());
+
+    for (const auto& value : data)
+        data_str.push_back(Model_Currency::toString(value, Model_Currency::GetBaseCurrency(), precision));
     this->addTotalRow(caption, cols, data_str);
 }
 

--- a/src/reports/htmlbuilder.h
+++ b/src/reports/htmlbuilder.h
@@ -59,6 +59,8 @@ public:
 
     /** Create an HTML header and returns as a wxString */
     void addHeader(int level, const wxString& header);
+    void showUserName();
+    void addReportCurrency();
     void addDateNow();
 
     /** Start a table element */
@@ -71,9 +73,10 @@ public:
     /** Add a special row that will format total values */
     void addTotalRow(const wxString& caption, int cols, double value);
 
-    /** Add a special row that will format total values */
+    /** Add a special rows that will format total values */
     void addTotalRow(const wxString& caption, int cols, const std::vector<wxString>& data);
-    void addTotalRow(const wxString& caption, int cols, const std::vector<double>& data);
+    void addCurrencyTotalRow(const wxString& caption, int cols, const std::vector<double>& data);
+    void addMoneyTotalRow(const wxString& caption, int cols, const std::vector<double>& data);
 
     /** Add a Table header cell */
     void addTableHeaderCell(const wxString& value, const bool numeric = false, const bool sortable = true, const int cols = 1, const bool center = false);

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -238,7 +238,7 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
     }
 
     hb.addDivContainer("shadow"); // Table Container
-    hb.startSortTable();
+    hb.startTable();
     {
         hb.startThead();
         {

--- a/src/reports/incexpenses.cpp
+++ b/src/reports/incexpenses.cpp
@@ -73,9 +73,11 @@ wxString mmReportIncomeExpenses::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, this->getReportTitle());
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), m_date_range->is_with_date());
         hb.addHeader(3, getAccountNames());
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();
@@ -187,9 +189,11 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle"); 
     {
+        hb.showUserName();
         hb.addHeader(2, this->getReportTitle());
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), m_date_range->is_with_date());
         hb.addHeader(3, getAccountNames());
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();
@@ -239,8 +243,7 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
         hb.startThead();
         {
             hb.startTableRow();
-            hb.addTableHeaderCell(_("Year"));
-            hb.addTableHeaderCell(_("Month"));
+            hb.addTableHeaderCell(_("Date"));
             hb.addTableHeaderCell(_("Income"), true);
             hb.addTableHeaderCell(_("Expenses"), true);
             hb.addTableHeaderCell(_("Difference"), true);
@@ -251,19 +254,30 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
 
         double total_expenses = 0.0;
         double total_income = 0.0;
+        wxString yearPrec;
         hb.startTbody();
         for (const auto &stats : incomeExpensesStats)
         {
             total_expenses += stats.second.second;
             total_income += stats.second.first;
 
+            wxString year = wxString() << stats.first / 100;
+            if (yearPrec != year)
+            {
+                hb.startAltTableRow();
+                    hb.addTableCell(year);
+                    hb.addEmptyTableCell(3);
+                hb.endTableRow();
+            }
             hb.startTableRow();
-            hb.addTableCell(wxString() << stats.first / 100);
-            hb.addTableCellMonth(static_cast<wxDateTime::Month>(stats.first % 100));
-            hb.addMoneyCell(stats.second.first);
-            hb.addMoneyCell(stats.second.second);
-            hb.addMoneyCell(stats.second.first - stats.second.second);
+            {
+                hb.addTableCellMonth(static_cast<wxDateTime::Month>(stats.first % 100));
+                hb.addMoneyCell(stats.second.first);
+                hb.addMoneyCell(stats.second.second);
+                hb.addMoneyCell(stats.second.first - stats.second.second);
+            }
             hb.endTableRow();
+            yearPrec = year;
         }
         hb.endTbody();
 
@@ -272,7 +286,7 @@ wxString mmReportIncomeExpensesMonthly::getHTMLText()
         totals.push_back(total_expenses);
         totals.push_back(total_income - total_expenses);
 
-        hb.addTotalRow(_("Total:"), 5, totals);
+        hb.addMoneyTotalRow(_("Total:"), 4, totals);
     }
     hb.endTable();
 

--- a/src/reports/myusage.cpp
+++ b/src/reports/myusage.cpp
@@ -112,6 +112,7 @@ wxString mmReportMyUsage::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle"); 
     {
+        hb.showUserName();
         hb.addHeader(2, this->getReportTitle());
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), m_date_range->is_with_date());
         hb.addDateNow();

--- a/src/reports/payee.cpp
+++ b/src/reports/payee.cpp
@@ -98,8 +98,10 @@ wxString mmReportPayeeExpenses::getHTMLText()
     hb.init();
     hb.addDivContainer("shadowTitle");
     {
+        hb.showUserName();
         hb.addHeader(2, getReportTitle());
         hb.DisplayDateHeading(m_date_range->start_date(), m_date_range->end_date(), m_date_range->is_with_date());
+        hb.addReportCurrency();
         hb.addDateNow();
     }
     hb.endDiv();
@@ -167,7 +169,7 @@ wxString mmReportPayeeExpenses::getHTMLText()
                 totals.push_back(positiveTotal_);
                 totals.push_back(negativeTotal_);
                 totals.push_back(positiveTotal_ + negativeTotal_);
-                hb.addTotalRow(_("Total:"), 4, totals);
+                hb.addMoneyTotalRow(_("Total:"), 4, totals);
             }
             hb.endTfoot();
         }

--- a/src/wizard_newaccount.cpp
+++ b/src/wizard_newaccount.cpp
@@ -19,6 +19,11 @@
 #include "wizard_newaccount.h"
 #include "mmhomepagepanel.h"
 #include "../resources/addacctwiz.xpm"
+
+wxBEGIN_EVENT_TABLE(mmAddAccountNamePage, wxWizardPageSimple)
+    EVT_WIZARD_PAGE_CHANGING(wxID_ANY, mmAddAccountNamePage::processPage)
+wxEND_EVENT_TABLE()
+
 //----------------------------------------------------------------------------
 
 mmAddAccountWizard::mmAddAccountWizard(wxFrame *frame)
@@ -70,25 +75,26 @@ void mmAddAccountWizard::RunIt()
     Destroy();
 }
 
-bool mmAddAccountNamePage::TransferDataFromWindow()
+void mmAddAccountNamePage::processPage(wxWizardEvent& event)
 {
-    bool result = true;
     const wxString account_name = textAccountName_->GetValue().Trim();
-    if ( account_name.IsEmpty())
+    parent_->accountName_ = account_name;
+    if (event.GetDirection())
     {
-        wxMessageBox(_("Account Name Invalid"), _("New Account"), wxOK|wxICON_ERROR, this);
-        result = false;
-    }
-    else
-    {
-        if (Model_Account::instance().get(account_name))
+        if ( account_name.IsEmpty())
         {
-            wxMessageBox(_("Account Name already exists"), _("New Account"), wxOK|wxICON_ERROR, this);
-            result = false;
+            wxMessageBox(_("Account Name Invalid"), _("New Account"), wxOK|wxICON_ERROR, this);
+            event.Veto();
+        }
+        else
+        {
+            if (Model_Account::instance().get(account_name))
+            {
+                wxMessageBox(_("Account Name already exists"), _("New Account"), wxOK|wxICON_ERROR, this);
+                event.Veto();
+            }
         }
     }
-    parent_->accountName_ = account_name;
-    return result;
 }
 
 mmAddAccountNamePage::mmAddAccountNamePage(mmAddAccountWizard* parent)

--- a/src/wizard_newaccount.h
+++ b/src/wizard_newaccount.h
@@ -45,11 +45,13 @@ class mmAddAccountNamePage : public wxWizardPageSimple
 {
 public:
     mmAddAccountNamePage(mmAddAccountWizard* parent);
-    virtual bool TransferDataFromWindow();
+    void processPage(wxWizardEvent& event);
 
 private:
     mmAddAccountWizard* parent_;
     wxTextCtrl* textAccountName_;
+
+    wxDECLARE_EVENT_TABLE();
 };
 //----------------------------------------------------------------------------
 


### PR DESCRIPTION
Reports now have common presentation format:

1. All reports displayed without currency symbols (I did add currency symbols to reports but they look 'too cluttered')
2. Added an indicator to the report headings to indicted what currency is being presented
3. Moved the MMEX username element into the single report header
4. For consistency, the inc/exp full month report now splits by year in a similar fashion to the 'Summary of accounts' 
